### PR TITLE
[update]NPCの継承先の変更をしました。

### DIFF
--- a/Assets/NPC/DevScripts/Hermit.cs
+++ b/Assets/NPC/DevScripts/Hermit.cs
@@ -1,10 +1,8 @@
 namespace TeamC
 {
     /// <summary>仙人の処理</summary>
-    public class Hermit : NPCSuperClass
+    public class Hermit : NPC
     {
-        public int GetCurrentLevel() => _currentLv;
-
         private void FixedUpdate()
         {
             //throw new NotImplementedException();

--- a/Assets/NPC/DevScripts/Poet.cs
+++ b/Assets/NPC/DevScripts/Poet.cs
@@ -1,11 +1,9 @@
 namespace TeamC
 {
     /// <summary>詩人の処理</summary>
-    public class Poet : NPCSuperClass
+    public class Poet : NPC
     {
         private int _effectMagnification = 1;
-
-        public int GetCurrentLevel() => _currentLv;
 
         //全てのNPCの効果を2×購入数倍する
         public int GetEffectMagnification() => _effectMagnification;

--- a/Assets/NPC/DevScripts/Thief.cs
+++ b/Assets/NPC/DevScripts/Thief.cs
@@ -1,10 +1,8 @@
 namespace TeamC
 {
     /// <summary>盗賊の処理</summary>
-    public class Thief : NPCSuperClass
+    public class Thief : NPC
     {
-        public int GetCurrentLevel() => _currentLv;
-
         private void FixedUpdate()
         {
             //throw new NotImplementedException();

--- a/Assets/NPC/DevScripts/Warrior.cs
+++ b/Assets/NPC/DevScripts/Warrior.cs
@@ -1,10 +1,8 @@
 namespace TeamC
 {
     /// <summary>戦士の処理</summary>
-    public class Warrior : NPCSuperClass
+    public class Warrior : NPC
     {
-        public int GetCurrentLevel() => _currentLv;
-
         private void FixedUpdate()
         {
             //throw new NotImplementedException();

--- a/Assets/NPC/DevScripts/Wizard.cs
+++ b/Assets/NPC/DevScripts/Wizard.cs
@@ -1,10 +1,8 @@
 namespace TeamC
 {
     /// <summary>魔法使いの処理</summary>
-    public class Wizard : NPCSuperClass
+    public class Wizard : NPC
     {
-        public int GetCurrentLevel() => _currentLv;
-
         public void WizardBuff()
         {
             //throw new NotImplementedException();

--- a/Assets/NPC/NPC.cs
+++ b/Assets/NPC/NPC.cs
@@ -19,6 +19,6 @@ namespace TeamC
     /// <summary> NPCの機能を提供 </summary>
     public class NPC : NPCSuperClass
     {
-        
+        public int GetCurrentLevel() => _currentLv;
     }
 }


### PR DESCRIPTION
NPCSuperClass -> NPC
に変更しました。

public int GetCurrentLevel() => _currentLv;
は同じ処理のためNPCに分離しました。